### PR TITLE
NoAndOperator analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ Enterprise-approved insane C# Roslyn Analyzers under the motto: "don't let produ
 
 * [`NoExtensionMethods`](https://www.reddit.com/r/dotnet/comments/1c4hz1z/linq_forbidden/) - especially LINQ. If classes were supposed to have these methods, they would have implemented via inheritance obviously.
 * [`NoVarDeclarations`](https://twitter.com/michaeljolley/status/1782767354184667538) - the `var` keyword is dangerous; we should all write C# with explicit types in every expression, like a 1990s Java program.
+* [`NoAndOperators`](https://twitter.com/willboulton) - disallow usage of the `&&` operator, instead you must be explicit by ruling falsehood.

--- a/src/EvilRoslynAnalyzers.Tests/BanAndTests.cs
+++ b/src/EvilRoslynAnalyzers.Tests/BanAndTests.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.CodeAnalysis;
+using Verify = EvilRoslynAnalyzers.Tests.Utilities.EvilVerifier<EvilRoslynAnalyzers.NoAndOperatorAnalyzer>;
+
+namespace EvilRoslynAnalyzers.Tests;
+
+public class BanAndTests
+{
+    [Fact]
+    public void DemonstrateDeMorgansLaw()
+    {
+        bool DeMorgansLawAnd(bool a, bool b) => !(!a || !b);
+        
+        Assert.Equal(true && false, DeMorgansLawAnd(true, false));
+        Assert.Equal(false && true, DeMorgansLawAnd(false, true));
+        Assert.Equal(true && true, DeMorgansLawAnd(true, true));
+        Assert.Equal(false && false, DeMorgansLawAnd(false, false));
+    }
+    
+    
+    [Fact]
+    public Task ShouldNotDetectDeMorgansLawUsage()
+    {
+        string testCode = @"
+using System;
+public class TestClass {
+    public void TestMethod() {
+        bool a = true;
+        bool b = false;
+        if(!(!a || !b))
+        {
+        }
+    }
+}
+";
+        return Verify.VerifyAnalyzer(testCode);
+    }
+    
+    
+    [Fact]
+    public Task ShouldDetectAndOperatorUsage()
+    {
+        string testCode = @"
+using System;
+public class TestClass {
+    public void TestMethod() {
+        bool a = true;
+        bool b = false;
+        if(a && b)
+        {
+        }
+    }
+}
+";
+        return Verify.VerifyAnalyzer(testCode,Verify.Diagnostic().WithSpan(7, 12, 7, 18).WithSeverity(DiagnosticSeverity.Error));
+    }
+}

--- a/src/EvilRoslynAnalyzers/NoAndOperatorAnalyzer.cs
+++ b/src/EvilRoslynAnalyzers/NoAndOperatorAnalyzer.cs
@@ -1,0 +1,35 @@
+﻿namespace EvilRoslynAnalyzers;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class NoAndOperatorAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "NoAndOperator";
+    
+    private static readonly string Title = "AndAlso operator is forbidden";
+    private static readonly string MessageFormat = "Using the && operator is not allowed";
+    private static readonly string Description = "All boolean and operator (&&) usages are forbidden in this codebase. Try using and expressions instead.";
+    private const string Category = "Usage";
+    
+    private static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+    
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeSyntaxNode, SyntaxKind.LogicalAndExpression);
+    }
+
+    private void AnalyzeSyntaxNode(SyntaxNodeAnalysisContext context)
+    {
+        var diag = Diagnostic.Create(Rule, context.Node.GetLocation());
+        context.ReportDiagnostic(diag);
+    }
+}

--- a/src/EvilRoslynAnalyzers/NoAndOperatorAnalyzer.cs
+++ b/src/EvilRoslynAnalyzers/NoAndOperatorAnalyzer.cs
@@ -12,7 +12,7 @@ public class NoAndOperatorAnalyzer : DiagnosticAnalyzer
     
     private static readonly string Title = "AndAlso operator is forbidden";
     private static readonly string MessageFormat = "Using the && operator is not allowed";
-    private static readonly string Description = "All boolean and operator (&&) usages are forbidden in this codebase. Try using and expressions instead.";
+    private static readonly string Description = "All boolean and operator (&&) usages are forbidden in this codebase. You must rule out your expressions being false!";
     private const string Category = "Usage";
     
     private static DiagnosticDescriptor Rule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);


### PR DESCRIPTION
Adds an analyzer which prevents the use of `&&` operator in boolean expressions. 